### PR TITLE
fix build with --target=i686-linux-android: *const i8 != *const u8

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ use std::ptr;
 
 /// Output log to android system.
 fn android_log(prio: log_ffi::LogPriority, tag: &CStr, msg: &CStr) {
-    unsafe { log_ffi::__android_log_write(prio as log_ffi::c_int, tag.as_ptr(), msg.as_ptr()) };
+    unsafe { log_ffi::__android_log_write(prio as log_ffi::c_int, tag.as_ptr() as *const log_ffi::c_char, msg.as_ptr() as *const log_ffi::c_char) };
 }
 
 struct PlatformLogger;


### PR DESCRIPTION
Compilation with `cargo build --target=i686-linux-android` failed, because of `char` on arm char is u8 on armeabi, and i8 on i686 or vise versa. 