### PR TITLE
check at least that we have no problem with syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+matrix:
+  allow_failures:
+    - rust: nightly
+os:
+  - linux
+  - osx
+
+before_script:
+  - rustup target add arm-linux-androideabi
+  - rustup target add armv7-linux-androideabi
+  - rustup target add aarch64-linux-android
+  - rustup target add i686-linux-android
+
+script:
+  - cargo check --target=arm-linux-androideabi
+  - cargo check --target=armv7-linux-androideabi
+  - cargo check --target=aarch64-linux-android
+  - cargo check --target=i686-linux-android
+  - cargo doc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ version = "0.3"
 
 [dependencies.android_log-sys]
 version = "0.1"
+
+[badges]
+travis-ci = { repository = "Nercury/android_logger-rs" }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 ## A logger which uses android logging backend
 
+[![Version](https://img.shields.io/crates/v/android_logger.svg)](https://crates.io/crates/android_logger)
+[![Build Status](https://travis-ci.org/Dushistov/android_logger-rs.png)](https://travis-ci.org/Dushistov/android_logger-rs)
+
 This, of course, works only under android and requires linking to `log` which
 is only available under android.
 


### PR DESCRIPTION
To prevent things like fixed in d59a22ae3a33a4a0c11098fa6d1f317c734c110b test build with all supported by rustup targets. Also budges from CI in theory (potentially) may icrease package raiting.

Note: in README.md url should be fixed to point travis-ci for  Nercury/android_logger-rs instead of my fork.