### PR TITLE
use str.contains() for filter matching

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,7 +268,7 @@ impl Filter {
 
         self.allow_module_paths
             .iter()
-            .any(|allowed_path| allowed_path == path)
+            .any(|allowed_path| path.contains(allowed_path))
     }
 }
 


### PR DESCRIPTION
`str.contains()` can match broader range of module name string, giving us more flexibility when configuring filter.