### PR TITLE
use env_logger filter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,8 @@ version = "0.4"
 [dependencies.android_log-sys]
 version = "0.1"
 
+[dependencies.env_logger]
+version = "0.6"
+
 [badges]
 travis-ci = { repository = "Nercury/android_logger-rs" }


### PR DESCRIPTION
Hi!

I had a go this morning at implementing #30 and I ended up changing quite a few things.

This breaks the API and I would understand if you don't want to merge it.

Here's what I've done
- [x] renamed the `Filter` struct into `Config`
- [x] moved tag configuration in the `Config` (this means we only need to grab one lock in the log function, which is nice)
- [x] removed the `allow_module_path` APIs
- [x] added a `with_filter` api that uses the goodness of the `env_logger` filters and can do all the `allow_module_path` could do but also a lot more, this means I've added a dependency to env_logger

