### PR TITLE
Allow constructing new instances of a logger with a config.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,15 @@ pub struct AndroidLogger {
     config: RwLock<Config>,
 }
 
+impl AndroidLogger {
+    /// Create new logger instance from config
+    pub fn new(config: Config) -> AndroidLogger {
+        AndroidLogger {
+            config: RwLock::new(config),
+        }
+    }
+}
+
 lazy_static! {
    static ref ANDROID_LOGGER: AndroidLogger = AndroidLogger::default();
 }


### PR DESCRIPTION
Our application uses [fern](https://crates.io/crates/fern) to log to multiple sinks and filter out various crates. The application is now being ported to Android, and it to log to Logcat, it'd be nice to use this crate's logger. But there's an issue with this crate - even though a `Config` is exposed to configure a `AndroidLogger` instance, there's no way to construct an `AndroidLogger` instance with a specific configuration. This PR changes that so an `AndroidLogger` can be constructed from the config.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nercury/android_logger-rs/32)
<!-- Reviewable:end -->
