### PR TITLE
Don't activate default features of env_logger

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ A logging implementation for `log` which hooks to android log output.
 keywords = ["android", "bindings", "log", "logger"]
 categories = ["api-bindings"]
 
+[features]
+default = ["regex"]
+regex = ["env_logger/regex"]
+
 [dependencies]
 lazy_static = "1.0"
 
@@ -22,6 +26,7 @@ version = "0.1"
 
 [dependencies.env_logger]
 version = "0.6"
+default-features = false
 
 [badges]
 travis-ci = { repository = "Nercury/android_logger-rs" }


### PR DESCRIPTION
env_logger comes with several optional-but-default-activated features,
including a dependency on regex.
There's no need for android_logger to require that. Deactivating default
features allows users of android_logger to define the features they
need.

<details>
We're using regex in our own library, but with [recent changes](https://github.com/rust-lang/regex/pull/613) we were able to reduce our library size by 30% or so. However, now upgrading to the latest android_logger pulls in the whole of regex again, without a way to prevent that. If android_logger just won't ask for the default features our own library is free to specify the final feature set (of course only as long as no _other_ library also pulls in regex with default features).
</details>