### PR TITLE
Upgrade env_logger dependency to 0.8.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.4"
 version = "0.2"
 
 [dependencies.env_logger]
-version = "0.7"
+version = "0.8"
 default-features = false
 
 [badges]


### PR DESCRIPTION
This is a breaking change since this crate exposes `env_logger` types publicly. But it would be good to migrate to the newer breaking release of `env_logger`. Allows users of this crate to use the latest `env_logger` without depending on two versions.