### PR TITLE
Add tests

### DIFF
--- a/tests/config_log_level.rs
+++ b/tests/config_log_level.rs
@@ -1,0 +1,9 @@
+extern crate android_logger;
+extern crate log;
+
+#[test]
+fn config_log_level() {
+    android_logger::init_once(android_logger::Config::default().with_min_level(log::Level::Trace));
+
+    assert_eq!(log::max_level(), log::LevelFilter::Trace);
+}

--- a/tests/default_init.rs
+++ b/tests/default_init.rs
@@ -1,0 +1,10 @@
+extern crate android_logger;
+extern crate log;
+
+#[test]
+fn default_init() {
+    android_logger::init_once(Default::default());
+
+    // android_logger has default log level "off"
+    assert_eq!(log::max_level(), log::LevelFilter::Off);
+}

--- a/tests/multiple_init.rs
+++ b/tests/multiple_init.rs
@@ -1,0 +1,12 @@
+extern crate android_logger;
+extern crate log;
+
+#[test]
+fn multiple_init() {
+    android_logger::init_once(android_logger::Config::default().with_min_level(log::Level::Trace));
+
+    // Second initialization should be silently ignored
+    android_logger::init_once(android_logger::Config::default().with_min_level(log::Level::Error));
+
+    assert_eq!(log::max_level(), log::LevelFilter::Trace);
+}


### PR DESCRIPTION
Most of the unit tests live inside src/lib.rs, with the exception of
those that require logger initialization. The latter need to run
independently in separate binaries, to ensure a separate global state.