### PR TITLE
Remove logger config locking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ default = ["regex"]
 regex = ["env_logger/regex"]
 
 [dependencies]
-lazy_static = "1.4"
+once_cell = "1.9"
 
 [dependencies.log]
 version = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,14 +65,12 @@
 
 #[cfg(target_os = "android")]
 extern crate android_log_sys as log_ffi;
-#[macro_use]
-extern crate lazy_static;
+extern crate once_cell;
+use once_cell::sync::OnceCell;
 #[macro_use]
 extern crate log;
 
 extern crate env_logger;
-
-use std::sync::RwLock;
 
 #[cfg(target_os = "android")]
 use log_ffi::LogPriority;
@@ -105,21 +103,20 @@ fn android_log(_priority: Level, _tag: &CStr, _msg: &CStr) {}
 
 /// Underlying android logger backend
 pub struct AndroidLogger {
-    config: RwLock<Config>,
+    config: OnceCell<Config>,
 }
 
 impl AndroidLogger {
     /// Create new logger instance from config
     pub fn new(config: Config) -> AndroidLogger {
         AndroidLogger {
-            config: RwLock::new(config),
+            config: OnceCell::from(config),
         }
     }
 }
 
-lazy_static! {
-   static ref ANDROID_LOGGER: AndroidLogger = AndroidLogger::default();
-}
+
+static ANDROID_LOGGER: OnceCell<AndroidLogger> = OnceCell::new();
 
 const LOGGING_TAG_MAX_LEN: usize = 23;
 const LOGGING_MSG_MAX_LEN: usize = 4000;
@@ -128,7 +125,7 @@ impl Default for AndroidLogger {
     /// Create a new logger with default config
     fn default() -> AndroidLogger {
         AndroidLogger {
-            config: RwLock::new(Config::default()),
+            config: OnceCell::from(Config::default()),
         }
     }
 }
@@ -140,8 +137,7 @@ impl Log for AndroidLogger {
 
     fn log(&self, record: &Record) {
         let config = self.config
-            .read()
-            .expect("failed to acquire android_log filter lock for read");
+            .get_or_init(Config::default);
 
         if !config.filter_matches(record) {
             return;
@@ -423,7 +419,7 @@ impl<'a> fmt::Write for PlatformLogWriter<'a> {
 /// This action does not require initialization. However, without initialization it
 /// will use the default filter, which allows all logs.
 pub fn log(record: &Record) {
-    ANDROID_LOGGER.log(record)
+    ANDROID_LOGGER.get_or_init(AndroidLogger::default).log(record)
 }
 
 /// Initializes the global logger with an android logger.
@@ -434,16 +430,13 @@ pub fn log(record: &Record) {
 /// It is ok to call this at the activity creation, and it will be
 /// repeatedly called on every lifecycle restart (i.e. screen rotation).
 pub fn init_once(config: Config) {
-    if let Err(err) = log::set_logger(&*ANDROID_LOGGER) {
+    let log_level = config.log_level;
+    let logger = ANDROID_LOGGER.get_or_init(|| AndroidLogger::new(config));
+
+    if let Err(err) = log::set_logger(logger) {
         debug!("android_logger: log::set_logger failed: {}", err);
-    } else {
-        if let Some(level) = config.log_level {
-            log::set_max_level(level.to_level_filter());
-        }
-        *ANDROID_LOGGER
-            .config
-            .write()
-            .expect("failed to acquire android_log filter lock for write") = config;
+    } else if let Some(level) = log_level {
+        log::set_max_level(level.to_level_filter());
     }
 }
 


### PR DESCRIPTION
This helps reduce overhead when fast bursts of logging occur and in general models what it actually does better. The logic only let a caller init the global logger once since it used `log::set_logger` but used a `RwLock` that never called `.write()` more than once.


Happy to drop the Clippy lint commit if you don't care for it.