### PR TITLE
Support selecting target buffer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,21 +85,69 @@ pub use env_logger::fmt::Formatter;
 
 pub(crate) type FormatFn = Box<dyn Fn(&mut dyn fmt::Write, &Record) -> fmt::Result + Sync + Send>;
 
+/// Identifies a specific log buffer to use when logging a message.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum LogId {
+    /// The main log buffer.
+    /// 
+    /// This is the only log buffer available to apps.
+    Main,
+
+    /// The radio log buffer.
+    Radio,
+
+    /// The event log buffer.
+    Events,
+
+    /// The system log buffer.
+    System,
+
+    /// The crash log buffer.
+    Crash,
+
+    /// The kernel log buffer.
+    Kernel,
+
+    /// The security log buffer.
+    Security,
+
+    /// The statistics log buffer.
+    Stats,
+}
+
+impl LogId {
+    #[cfg(target_os = "android")]
+    fn to_native(log_id: Option<Self>) -> log_ffi::log_id_t {
+        match log_id {
+            Some(LogId::Main) => log_ffi::log_id_t::MAIN,
+            Some(LogId::Radio) => log_ffi::log_id_t::RADIO,
+            Some(LogId::Events) => log_ffi::log_id_t::EVENTS,
+            Some(LogId::System) => log_ffi::log_id_t::SYSTEM,
+            Some(LogId::Crash) => log_ffi::log_id_t::CRASH,
+            Some(LogId::Kernel) => log_ffi::log_id_t::KERNEL,
+            Some(LogId::Security) => log_ffi::log_id_t::SECURITY,
+            Some(LogId::Stats) => log_ffi::log_id_t::STATS,
+            None => log_ffi::log_id_t::DEFAULT,
+        }
+    }
+}
+
 /// Output log to android system.
 #[cfg(target_os = "android")]
-fn android_log(prio: log_ffi::LogPriority, tag: &CStr, msg: &CStr) {
+fn android_log(log_id: log_ffi::log_id_t, prio: log_ffi::LogPriority, tag: &CStr, msg: &CStr) {
     unsafe {
-        log_ffi::__android_log_write(
-            prio as log_ffi::c_int,
+        log_ffi::__android_log_buf_write(
+            log_id as i32,
+            prio as i32,
             tag.as_ptr() as *const log_ffi::c_char,
             msg.as_ptr() as *const log_ffi::c_char,
-        )
+        );
     };
 }
 
 /// Dummy output placeholder for tests.
 #[cfg(not(target_os = "android"))]
-fn android_log(_priority: Level, _tag: &CStr, _msg: &CStr) {}
+fn android_log(_log_id: Option<LogId>, _priority: Level, _tag: &CStr, _msg: &CStr) {}
 
 /// Underlying android logger backend
 pub struct AndroidLogger {
@@ -160,7 +208,7 @@ impl Log for AndroidLogger {
 
         // message must not exceed LOGGING_MSG_MAX_LEN
         // therefore split log message into multiple log calls
-        let mut writer = PlatformLogWriter::new(record.level(), tag);
+        let mut writer = PlatformLogWriter::new(config.log_id, record.level(), tag);
 
         // If a custom tag is used, add the module path to the message.
         // Use PlatformLogWriter to output chunks if they exceed max size.
@@ -205,6 +253,7 @@ impl AndroidLogger {
 #[derive(Default)]
 pub struct Config {
     log_level: Option<Level>,
+    log_id: Option<LogId>,
     filter: Option<env_logger::filter::Filter>,
     tag: Option<CString>,
     custom_format: Option<FormatFn>,
@@ -217,6 +266,15 @@ impl Config {
     /// `Warn` is set, the `Error` is logged too, but `Info` isn't.
     pub fn with_min_level(mut self, level: Level) -> Self {
         self.log_level = Some(level);
+        self
+    }
+
+    /// Change which log buffer is used
+    ///
+    /// By default, logs are sent to the `Main` log. Other logging buffers may only be accessible
+    /// to certain processes.
+    pub fn with_log_id(mut self, log_id: LogId) -> Self {
+        self.log_id = Some(log_id);
         self
     }
 
@@ -259,6 +317,8 @@ impl Config {
 pub struct PlatformLogWriter<'a> {
     #[cfg(target_os = "android")] priority: LogPriority,
     #[cfg(not(target_os = "android"))] priority: Level,
+    #[cfg(target_os = "android")] log_id: log_ffi::log_id_t,
+    #[cfg(not(target_os = "android"))] log_id: Option<LogId>,
     len: usize,
     last_newline_index: usize,
     tag: &'a CStr,
@@ -267,7 +327,7 @@ pub struct PlatformLogWriter<'a> {
 
 impl<'a> PlatformLogWriter<'a> {
     #[cfg(target_os = "android")]
-    pub fn new(level: Level, tag: &CStr) -> PlatformLogWriter {
+    pub fn new(log_id: Option<LogId>, level: Level, tag: &CStr) -> PlatformLogWriter {
         #[allow(deprecated)] // created an issue #35 for this
         PlatformLogWriter {
             priority: match level {
@@ -277,6 +337,7 @@ impl<'a> PlatformLogWriter<'a> {
                 Level::Error => LogPriority::ERROR,
                 Level::Trace => LogPriority::VERBOSE,
             },
+            log_id: LogId::to_native(log_id),
             len: 0,
             last_newline_index: 0,
             tag,
@@ -285,10 +346,11 @@ impl<'a> PlatformLogWriter<'a> {
     }
 
     #[cfg(not(target_os = "android"))]
-    pub fn new(level: Level, tag: &CStr) -> PlatformLogWriter {
+    pub fn new(log_id: Option<LogId>, level: Level, tag: &CStr) -> PlatformLogWriter {
         #[allow(deprecated)] // created an issue #35 for this
         PlatformLogWriter {
             priority: level,
+            log_id,
             len: 0,
             last_newline_index: 0,
             tag,
@@ -344,7 +406,7 @@ impl<'a> PlatformLogWriter<'a> {
         });
 
         let msg: &CStr = unsafe { CStr::from_ptr(mem::transmute(self.buffer.as_ptr())) };
-        android_log(self.priority, self.tag, msg);
+        android_log(self.log_id, self.priority, self.tag, msg);
 
         *unsafe { self.buffer.get_unchecked_mut(len) } = last_byte;
     }
@@ -441,9 +503,11 @@ mod tests {
         // Filter is checked in config_filter_match below.
         let config = Config::default()
             .with_min_level(Level::Trace)
+            .with_log_id(LogId::System)
             .with_tag("my_app");
 
         assert_eq!(config.log_level, Some(Level::Trace));
+        assert_eq!(config.log_id, Some(LogId::System));
         assert_eq!(config.tag, Some(CString::new("my_app").unwrap()));
     }
 
@@ -514,7 +578,7 @@ mod tests {
     fn platform_log_writer_init_values() {
         let tag = CStr::from_bytes_with_nul(b"tag\0").unwrap();
 
-        let writer = PlatformLogWriter::new(Level::Warn, tag);
+        let writer = PlatformLogWriter::new(None, Level::Warn, tag);
 
         assert_eq!(writer.tag, tag);
         // Android uses LogPriority instead, which doesn't implement equality checks
@@ -613,6 +677,10 @@ mod tests {
     }
 
     fn get_tag_writer() -> PlatformLogWriter<'static> {
-        PlatformLogWriter::new(Level::Warn, CStr::from_bytes_with_nul(b"tag\0").unwrap())
+        PlatformLogWriter::new(
+            None,
+            Level::Warn,
+            CStr::from_bytes_with_nul(b"tag\0").unwrap(),
+        )
     }
 }


### PR DESCRIPTION
Implementation for #49.

* Add `LogId` enum to identify the different log buffers.
* Add an argument to `PlatformLogWriter::new` to allow a target buffer to be specified.
* Update `Config` to allow specifying a target buffer.

---

This change, as it exists currently, is a breaking change for any users who are currently calling `PlatformLogWriter::new` directly. It should not break any users who are using `Config` with `init_once`. If this is undesirable then I'm open to updating the PR to avoid breaking changes.

Note also that these changes depend on an update to android_log-sys in order to expose `__android_log_buf_write`. See Nercury/android_log-sys-rs#4.