### PR TITLE
allow creating a PlatformLogWriter directly from a priority

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,21 +267,26 @@ pub struct PlatformLogWriter<'a> {
 
 impl<'a> PlatformLogWriter<'a> {
     #[cfg(target_os = "android")]
-    pub fn new(level: Level, tag: &CStr) -> PlatformLogWriter {
+    pub fn new_with_priority(priority: log_ffi::LogPriority, tag: &CStr) -> PlatformLogWriter {
         #[allow(deprecated)] // created an issue #35 for this
         PlatformLogWriter {
-            priority: match level {
-                Level::Warn => LogPriority::WARN,
-                Level::Info => LogPriority::INFO,
-                Level::Debug => LogPriority::DEBUG,
-                Level::Error => LogPriority::ERROR,
-                Level::Trace => LogPriority::VERBOSE,
-            },
+            priority,
             len: 0,
             last_newline_index: 0,
             tag,
             buffer: uninit_array(),
         }
+    }
+
+    #[cfg(target_os = "android")]
+    pub fn new(level: Level, tag: &CStr) -> PlatformLogWriter {
+        Self::new_with_priority(match level {
+            Level::Warn => LogPriority::WARN,
+            Level::Info => LogPriority::INFO,
+            Level::Debug => LogPriority::DEBUG,
+            Level::Error => LogPriority::ERROR,
+            Level::Trace => LogPriority::VERBOSE,
+        })
     }
 
     #[cfg(not(target_os = "android"))]


### PR DESCRIPTION
This allows for better ergonomics for users that want to use the PlatformLogWriter without using the `log` crate directly, e.g. when using another logging framework to log (like slog). Without this, callers need to first map to a log::Level instead of directly mapping to Android priorities.
