### PR TITLE
Bump env_logger minor version from 0.9 to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.4"
 version = "0.2"
 
 [dependencies.env_logger]
-version = "0.9"
+version = "0.10"
 default-features = false
 
 [badges]


### PR DESCRIPTION
env_logger replaced dependencies itself which have a dubious security track record or other issues. Other than that MSRV has been raised to 1.60.