### PR TITLE
Fix compilation for Android targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,26 +28,12 @@ jobs:
           - i686-linux-android
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - name: Install Rust ${{ matrix.toolchain }}
-        uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@${{ matrix.toolchain }}
         with:
-          profile: minimal
-          toolchain: ${{ matrix.toolchain }}
           target: ${{ matrix.target }}
 
-      - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-
-      - name: Generate docs
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-
-      - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - run: cargo build --target=${{ matrix.target }}
+      - run: cargo doc --target=${{ matrix.target }}
+      - run: cargo test --target=${{ matrix.target }}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,13 +292,16 @@ impl<'a> PlatformLogWriter<'a> {
 
     #[cfg(target_os = "android")]
     pub fn new(level: Level, tag: &CStr) -> PlatformLogWriter {
-        Self::new_with_priority(match level {
-            Level::Warn => LogPriority::WARN,
-            Level::Info => LogPriority::INFO,
-            Level::Debug => LogPriority::DEBUG,
-            Level::Error => LogPriority::ERROR,
-            Level::Trace => LogPriority::VERBOSE,
-        })
+        Self::new_with_priority(
+            match level {
+                Level::Warn => LogPriority::WARN,
+                Level::Info => LogPriority::INFO,
+                Level::Debug => LogPriority::DEBUG,
+                Level::Error => LogPriority::ERROR,
+                Level::Trace => LogPriority::VERBOSE,
+            },
+            tag,
+        )
     }
 
     #[cfg(not(target_os = "android"))]


### PR DESCRIPTION
Fixes #58 

Additionally, reworks CI pipeline:
- runs checks for `--target ${{ matrix.target }}`
- switches to `dtolnay/rust-toolchain` action (`actions-rs` seems to be somewhat [deprecated](https://github.com/actions-rs/toolchain/issues/216))