### PR TITLE
Fix bug only values equal to the set level are logged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [0.12.0] · 2023-01-?? (unreleased)
+[0.12.0]: /../../tree/v0.12.0
+
+[Diff](/../../compare/v0.11.3...v0.12.0)
+
+### Added
+
+- `Config::with_max_level()` method to filters logs via `log::LevelFilter`. ([#62])
+
+### Deprecated
+
+- `Config::with_min_level()` method accepting `log::Level`. ([#62])
+
+### Fixed
+
+- Incorrect logs level filtering. ([#62])
+
+[#62]: /../../pull/62
+
+
+
+
 ## [0.11.3] · 2022-12-20
 [0.11.3]: /../../tree/v0.11.3
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ use android_logger::{Config,FilterBuilder};
 fn native_activity_create() {
     android_logger::init_once(
         Config::default()
-            .with_filter_level(LevelFilter::Trace) // limit log level
+            .with_max_level(LevelFilter::Trace) // limit log level
             .with_tag("mytag") // logs will show under mytag tag
             .with_filter( // configure messages for specific crate
                 FilterBuilder::new()
@@ -52,7 +52,8 @@ use android_logger::Config;
 
 fn native_activity_create() {
     android_logger::init_once(
-        Config::default().with_filter_level(LevelFilter::Trace));
+        Config::default().with_max_level(LevelFilter::Trace),
+    );
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ Example of initialization on activity creation, with log configuration:
 #[macro_use] extern crate log;
 extern crate android_logger;
 
-use log::Level;
+use log::LevelFilter;
 use android_logger::{Config,FilterBuilder};
 
 fn native_activity_create() {
     android_logger::init_once(
         Config::default()
-            .with_min_level(Level::Trace) // limit log level
+            .with_filter_level(LevelFilter::Trace) // limit log level
             .with_tag("mytag") // logs will show under mytag tag
             .with_filter( // configure messages for specific crate
                 FilterBuilder::new()
@@ -47,12 +47,12 @@ To allow all logs, use the default configuration with min level Trace:
 #[macro_use] extern crate log;
 extern crate android_logger;
 
-use log::Level;
+use log::LevelFilter;
 use android_logger::Config;
 
 fn native_activity_create() {
     android_logger::init_once(
-        Config::default().with_min_level(Level::Trace));
+        Config::default().with_filter_level(LevelFilter::Trace));
 }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -509,6 +509,15 @@ mod tests {
         assert!(FORMAT_FN_WAS_CALLED.load(Ordering::SeqCst));
     }
 
+    #[test]
+    fn logger_enabled_threshold() {
+        let logger = AndroidLogger::new(Config::default().with_filter_level(LevelFilter::Info));
+
+        assert!(logger.enabled(&log::MetadataBuilder::new().level(Level::Warn).build()));
+        assert!(logger.enabled(&log::MetadataBuilder::new().level(Level::Info).build()));
+        assert!(!logger.enabled(&log::MetadataBuilder::new().level(Level::Debug).build()));
+    }
+
     // Test whether the filter gets called correctly. Not meant to be exhaustive for all filter
     // options, as these are handled directly by the filter itself.
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@ impl Log for AndroidLogger {
     fn enabled(&self, metadata: &Metadata) -> bool {
         let config = self.config();
         // todo: consider __android_log_is_loggable.
-        Some(metadata.level()) >= config.log_level
+        Some(metadata.level()) <= config.log_level
     }
 
     fn log(&self, record: &Record) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -492,13 +492,6 @@ mod tests {
         assert!(FORMAT_FN_WAS_CALLED.load(Ordering::SeqCst));
     }
 
-    #[test]
-    fn logger_always_enabled() {
-        let logger = AndroidLogger::new(Config::default());
-
-        assert!(logger.enabled(&log::MetadataBuilder::new().build()));
-    }
-
     // Test whether the filter gets called correctly. Not meant to be exhaustive for all filter
     // options, as these are handled directly by the filter itself.
     #[test]

--- a/tests/config_log_level.rs
+++ b/tests/config_log_level.rs
@@ -4,7 +4,7 @@ extern crate log;
 #[test]
 fn config_log_level() {
     android_logger::init_once(
-        android_logger::Config::default().with_filter_level(log::LevelFilter::Trace),
+        android_logger::Config::default().with_max_level(log::LevelFilter::Trace),
     );
 
     assert_eq!(log::max_level(), log::LevelFilter::Trace);

--- a/tests/config_log_level.rs
+++ b/tests/config_log_level.rs
@@ -3,7 +3,9 @@ extern crate log;
 
 #[test]
 fn config_log_level() {
-    android_logger::init_once(android_logger::Config::default().with_min_level(log::Level::Trace));
+    android_logger::init_once(
+        android_logger::Config::default().with_filter_level(log::LevelFilter::Trace),
+    );
 
     assert_eq!(log::max_level(), log::LevelFilter::Trace);
 }

--- a/tests/multiple_init.rs
+++ b/tests/multiple_init.rs
@@ -3,10 +3,14 @@ extern crate log;
 
 #[test]
 fn multiple_init() {
-    android_logger::init_once(android_logger::Config::default().with_min_level(log::Level::Trace));
+    android_logger::init_once(
+        android_logger::Config::default().with_filter_level(log::LevelFilter::Trace),
+    );
 
     // Second initialization should be silently ignored
-    android_logger::init_once(android_logger::Config::default().with_min_level(log::Level::Error));
+    android_logger::init_once(
+        android_logger::Config::default().with_filter_level(log::LevelFilter::Error),
+    );
 
     assert_eq!(log::max_level(), log::LevelFilter::Trace);
 }

--- a/tests/multiple_init.rs
+++ b/tests/multiple_init.rs
@@ -4,12 +4,12 @@ extern crate log;
 #[test]
 fn multiple_init() {
     android_logger::init_once(
-        android_logger::Config::default().with_filter_level(log::LevelFilter::Trace),
+        android_logger::Config::default().with_max_level(log::LevelFilter::Trace),
     );
 
     // Second initialization should be silently ignored
     android_logger::init_once(
-        android_logger::Config::default().with_filter_level(log::LevelFilter::Error),
+        android_logger::Config::default().with_max_level(log::LevelFilter::Error),
     );
 
     assert_eq!(log::max_level(), log::LevelFilter::Trace);


### PR DESCRIPTION
The document says that if `Warn` is set, `Error` will also be logged, but not `Info`. But in fact, if `Warn` is set, only `Warn` is logged, not `Error`.
I think this is a bug caused by the comparison operator.