### PR TITLE
Fix buf_id issues with older SDK API version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [0.13.1] · 2023-03-??
+[0.13.1]: /../../tree/v0.13.1
+
+[Diff](/../../compare/v0.13.0...v0.13.1)
+
+### Fixed
+
+- Missing logs on [Android] API 26 and earlier. ([#66], [#67])
+
+[#66]: /../../issues/66
+[#67]: /../../pull/67
+
+
+
+
 ## [0.13.0] · 2023-02-14
 [0.13.0]: /../../tree/v0.13.0
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ pub enum LogId {
 
 #[cfg(target_os = "android")]
 impl LogId {
-    fn to_native(log_id: Option<Self>) -> Option<log_ffi::log_id_t> {
+    const fn to_native(log_id: Option<Self>) -> Option<log_ffi::log_id_t> {
         match log_id {
             Some(Self::Main) => Some(log_ffi::log_id_t::MAIN),
             Some(Self::Radio) => Some(log_ffi::log_id_t::RADIO),


### PR DESCRIPTION
As per user report at least SDKv26 does not resolve LOG_ID_DEFAULT to LOG_ID_MAIN internally, which forces users to set LOG_ID_MAIN explicitly.

Rework android_log function to accept optional buf_id and use __android_log_write FFI function if no buf_id specified. This will return previous behavior for users that do not need to override buf_id.

Closes: https://github.com/Nercury/android_logger-rs/issues/66
Fixes: fee1beabd33e ("Support selecting target buffer of Android logging system")